### PR TITLE
Fix type errors

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -21,7 +21,8 @@
     "react-konva": "^18.2.10",
     "react-redux": "^9.1.2",
     "react-router-dom": "^6.26.2",
-    "redux-persist": "^6.0.0"
+    "redux-persist": "^6.0.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.10.0",

--- a/packages/client/src/features/drawBoard/DrawBoard.tsx
+++ b/packages/client/src/features/drawBoard/DrawBoard.tsx
@@ -76,9 +76,8 @@ const createEventMapper: CreateEventMapper = (
       const points = draft.points;
       if (!isDrawing || !isDragging || !points || points.length < 2) return;
       const { offsetX, offsetY } = e.evt;
-      const anchorPoint = [points[0] + offsetX, points[1] + offsetY].map(
-        (x) => x / 2,
-      );
+      const [x = 0, y = 0] = points;
+      const anchorPoint = [x + offsetX, y + offsetY].map((v) => v / 2);
       dispatch(
         setDraft({
           ...draft,
@@ -108,11 +107,11 @@ const createEventMapper: CreateEventMapper = (
       const { points } = draft;
       if (!isDrawing || !points) return;
       const { offsetX, offsetY } = e.evt;
-      const center = [points[0] + offsetX, points[1] + offsetY].map(
-        (x) => x / 2,
-      );
-      const radius = [center[0] - offsetX, center[1] - offsetY]
-        .map((x) => Math.abs(x))
+      const [x = 0, y = 0] = points;
+      const center = [x + offsetX, y + offsetY].map((v) => v / 2);
+      const [centerX = 0, centerY = 0] = center;
+      const radius = [centerX - offsetX, centerY - offsetY]
+        .map((v) => Math.abs(v))
         .reduce((prev, curr) => Math.min(prev, curr));
       dispatch(setDraft({ ...draft, x: center[0], y: center[1], radius }));
     },

--- a/packages/client/src/features/drawBoard/drawBoardSlice.ts
+++ b/packages/client/src/features/drawBoard/drawBoardSlice.ts
@@ -64,8 +64,11 @@ export const drawBoardSlice = createSlice({
     modifyProp: ({ nodes }, { payload }: PayloadAction<NodeProp>) => {
       const index = nodes.findIndex((x) => x.prop.id === payload.id);
       if (index !== -1) {
-        const { prop } = nodes[index];
-        nodes[index].prop = { ...prop, ...payload };
+        const node = nodes[index];
+        if (!node) return;
+
+        const { prop } = node;
+        node.prop = { ...prop, ...payload };
         return;
       }
     },

--- a/packages/client/src/features/quadCurve/QuadCurve.tsx
+++ b/packages/client/src/features/quadCurve/QuadCurve.tsx
@@ -24,11 +24,14 @@ export const QuadCurve = ({
   const [anchor, setAnchor] = React.useState<number[]>(anchorPoint ?? []);
 
   const sceneFunc = (ctx: Context, shape: ShapeType) => {
+    const [anchorX = 0, anchorY = 0] = anchor;
+    const [x0 = 0, y0 = 0, x1 = 0, y1 = 0] = points;
+
     ctx.beginPath();
-    ctx.moveTo(points[0], points[1]);
+    ctx.moveTo(x0, y0);
     if (anchorPoint && anchorPoint.length === 2)
-      ctx.quadraticCurveTo(anchor[0], anchor[1], points[2], points[3]);
-    ctx.lineTo(points[2], points[3]);
+      ctx.quadraticCurveTo(anchorX, anchorY, x1, y1);
+    ctx.lineTo(x1, y1);
     ctx.fillStrokeShape(shape);
   };
 
@@ -43,7 +46,7 @@ export const QuadCurve = ({
     },
     handleDragEnd(e: KonvaEventObject<DragEvent>) {
       e.cancelBubble = true;
-      onAnchorDragEnd ? onAnchorDragEnd(anchor) : null;
+      onAnchorDragEnd?.(anchor);
     },
     handleMouseUp(e: KonvaEventObject<MouseEvent>) {
       e.cancelBubble = true;

--- a/packages/client/src/pages/error-page.tsx
+++ b/packages/client/src/pages/error-page.tsx
@@ -1,15 +1,22 @@
 import { useRouteError } from "react-router-dom";
 import classes from "./error-page.module.css";
+import { z } from "zod";
+
+const errorSchema = z.object({
+  statusText: z.string().optional(),
+  message: z.string().optional(),
+});
 
 export default function ErrorPage() {
   const error = useRouteError();
   console.error(error);
+  const parsedError = errorSchema.parse(error);
   return (
     <div className={classes["error-page"]}>
       <h1>Oops!</h1>
       <p>Sorry, an unexpected error has occurred.</p>
       <p>
-        <i>{error.statusText || error.message}</i>
+        <i>{parsedError.statusText || parsedError.message}</i>
       </p>
     </div>
   );

--- a/packages/types/tsconfig.base.json
+++ b/packages/types/tsconfig.base.json
@@ -3,6 +3,5 @@
   "compilerOptions": {
     "strict": true,
     "noUncheckedIndexedAccess": true,
-    "exactOptionalPropertyTypes": true
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       redux-persist:
         specifier: ^6.0.0
         version: 6.0.0(react@18.3.1)(redux@5.0.1)
+      zod:
+        specifier: ^3.23.8
+        version: 3.23.8
     devDependencies:
       '@eslint/js':
         specifier: ^9.10.0
@@ -4714,6 +4717,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
 snapshots:
 
@@ -9855,3 +9861,5 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.23.8: {}


### PR DESCRIPTION
- fix type errors caused by `noUncheckedIndexedAccess`
- turn off `exactOptionalPropertyTypes`
  reason: bad DX
  I had to append `??` to every optional prop to resolve the type errors since third-party libraries don't explicitly annotate the undefined type in their components' prop types. It feels bad to keep repeating the same thing.